### PR TITLE
Se añade en el pom.xml del root (mb2g-mm-maven) el dependencyManageme…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Generacion proyecto Multi-Modulo
 - Se añade en el pom.xml del root (mb2g-mm-maven) el plugin flatten-maven-plugin para aplanar los pom.xml
 - Se añade en el pom.xml del root (mb2g-mm-maven) el pluggn maven-enforcer-plugin para asegurar que la version
   del java es 19 o superior, y la de maven es 3.8.6 o superior
+- Se añade en el pom.xml del root (mb2g-mm-maven) el dependencyManagement para declarar el groupId, artifactId y version
+  de todas las dependencias extenas de los hijos. En el pom.xlm de los hijos no se pone la version
+  De esta forma el mantenimiento de estas versiones se hace en un solo sitio.
 
 ## Modulos generados
 1. jpa-entities

--- a/converts/pom.xml
+++ b/converts/pom.xml
@@ -9,10 +9,6 @@
 
     <artifactId>converts</artifactId>
 
-    <properties>
-        <mapstruct.version>1.6.3</mapstruct.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.example</groupId>
@@ -24,12 +20,13 @@
             <artifactId>web-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- La version de mapstruct esta declarada en el pom.xml padre (mb2g-mm-maven) -->
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
-            <version>${mapstruct.version}</version>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/from-intellij/pom.xml
+++ b/from-intellij/pom.xml
@@ -11,30 +11,27 @@
 
     <properties>
         <java.version>19</java.version>
-        <junit.version>5.13.0-M2</junit.version>
     </properties>
 
+    <!-- Las versiones de los tres artifactId estan declaradas en el pom.xml padre (mb2g-mm-maven) -->
     <dependencies>
         <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
         <!-- JUnit5 -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin -->
         <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.12</version>
         </dependency>
     </dependencies>
 

--- a/jpa-entities/pom.xml
+++ b/jpa-entities/pom.xml
@@ -11,20 +11,20 @@
     </parent>
 
     <artifactId>jpa-entities</artifactId>
+
     <packaging>jar</packaging>
 
+    <!-- Las versiones de hibernate-core y lombok estan declaradas en el pom.xml padre (mb2g-mm-maven) -->
     <dependencies>
         <!-- https://mvnrepository.com/artifact/org.hibernate.orm/hibernate-core -->
         <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>6.6.12.Final</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.36</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,6 @@
     <packaging>pom</packaging>
 
 
-    <!--> eliminado module from-imtellij -->
     <modules>
         <module>jpa-entities</module>
         <module>from-intellij</module>
@@ -25,9 +24,74 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>24</java.version>
+        <mapstruct.version>1.6.3</mapstruct.version>
+        <jaxb.version>2.3.0</jaxb.version>
+        <hiberante.version>6.6.12.Final</hiberante.version>
+        <lombok.version>1.18.36</lombok.version>
+        <junit.version>5.13.0-M2</junit.version>
+        <jacoco.version>0.8.12</jacoco.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>
+
+    <!--> se crea una dependencyManagement que va a ser usada por el resto de los pom hijos
+     con los groupId, artifactId y version de las dependencias externas al proyecto
+     -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.mapstruct</groupId>
+                <artifactId>mapstruct</artifactId>
+                <version>${mapstruct.version}</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/org.hibernate.orm/hibernate-core -->
+            <dependency>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-core</artifactId>
+                <version>${hiberante.version}</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-core</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
+            <!-- JUnit5 -->
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit.version}</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit.version}</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin -->
+            <dependency>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
 
     <build>

--- a/web-api/pom.xml
+++ b/web-api/pom.xml
@@ -9,25 +9,19 @@
 
     <artifactId>web-api</artifactId>
 
-    <properties>
-        <jaxb.version>2.3.0</jaxb.version>
-    </properties>
-
+    <!-- Las versiones de los tres artifactId estan declaradas en el pom.xml padre (mb2g-mm-maven) -->
     <dependencies>
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>${jaxb.version}</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-core</artifactId>
-            <version>${jaxb.version}</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
-            <version>${jaxb.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
…nt para declarar el groupId, artifactId y version de todas las dependencias extenas de los hijos. En el pom.xlm de los hijos no se pone la version. De esta forma el mantenimiento de estas versiones se hace en un solo sitio.